### PR TITLE
fix crash in 3.4

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -15,7 +15,7 @@ void RunMain(HMODULE *phModule)
 	freopen_s((FILE **)stderr, "CONOUT$", "w", stderr);
 	SetConsoleOutputCP(CP_UTF8);
 
-	DebuggerBypassPre();
+	// DebuggerBypassPre();
 
 	while (GetModuleHandle(L"UserAssembly.dll") == nullptr) {
 		LOG("UserAssembly.dll isn't initialized. Waiting for 2 second.");


### PR DESCRIPTION
When I use GenshinDebuggerByPass in "Genshin v3.4“, the game crashed when the UserAssembly.dll have loaded. And when I delete the "DebuggerBypassPre()", this problem no longer occurs. 
I don't know what reason cause game crash, I think may be UserAssembly.DllMain check the head of NtSetInformationThread.